### PR TITLE
Throw \Exception not \Error.

### DIFF
--- a/src/Entity/SafeEchoEntityWrapper.php
+++ b/src/Entity/SafeEchoEntityWrapper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\SafeEcho\Entity;
 
-use Error;
+use Exception;
 
 //TODO: Implement callStatic
 abstract class SafeEchoEntityWrapper
@@ -30,62 +30,62 @@ abstract class SafeEchoEntityWrapper
      *
      * @param mixed $entity
      *
-     * @throws Error
+     * @throws Exception
      */
     public function wrap($entity): void
     {
         if (!is_object($entity)) {
-            throw new Error('Only objects can be wrapped');
+            throw new Exception('Only objects can be wrapped');
         }
 
         $this->wrappedEntity = $entity;
     }
 
     /**
-     * @throws Error
+     * @throws Exception
      */
     public function __call(string $name, array $arguments = null)
     {
         if (method_exists($this->getWrappedEntity(), $name)) {
             return $this->attemptSafeEcho(call_user_func_array([$this->getWrappedEntity(), $name], $arguments));
         }
-        throw new Error($this->undefinedMethod($name));
+        throw new Exception($this->undefinedMethod($name));
     }
 
     /**
-     * @throws Error
+     * @throws Exception
      */
     public function __get(string $name)
     {
         if (property_exists(get_class($this->getWrappedEntity()), $name)) {
             return $this->attemptSafeEcho($this->getWrappedEntity()->$name);
         }
-        throw new Error($this->undefinedProperty($name));
+        throw new Exception($this->undefinedProperty($name));
     }
 
     /**
-     * @throws Error
+     * @throws Exception
      */
     public function __set(string $name, $value): void
     {
         if (property_exists(get_class($this->getWrappedEntity()), $name)) {
             $this->getWrappedEntity()->$name = $value;
         } else {
-            throw new Error($this->undefinedProperty($name));
+            throw new Exception($this->undefinedProperty($name));
         }
     }
 
     /**
-     * Gets the entity that is currently wrapped, or throws an Error.
+     * Gets the entity that is currently wrapped, or throws an Exception.
      *
-     * @throws Error
+     * @throws Exception
      *
      * @return mixed
      */
     private function getWrappedEntity()
     {
         if (!isset($this->wrappedEntity)) {
-            throw new Error('No wrapped object defined. Did you forget to call [wrap]?');
+            throw new Exception('No wrapped object defined. Did you forget to call [wrap]?');
         }
 
         return $this->wrappedEntity;

--- a/tests/Entity/SafeWrapperTest.php
+++ b/tests/Entity/SafeWrapperTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\SafeEcho\Entity;
 
-use Error;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 class SafeWrapperTest extends TestCase
@@ -13,7 +13,7 @@ class SafeWrapperTest extends TestCase
      * @param $customerId
      * @param $customerSentence
      *
-     * @throws Error
+     * @throws Exception
      *
      * @return SafeEchoEntityWrapper
      */
@@ -90,7 +90,7 @@ class SafeWrapperTest extends TestCase
     }
 
     /**
-     * @expectedException \Error
+     * @expectedException \Exception
      * @expectedExceptionMessage No wrapped object defined. Did you forget to call [wrap]?
      */
     public function testNoWrappedObject(): void
@@ -101,7 +101,7 @@ class SafeWrapperTest extends TestCase
     }
 
     /**
-     * @expectedException \Error
+     * @expectedException \Exception
      * @expectedExceptionMessage Undefined property Linio\SafeEcho\Entity\Customer::$getDNExist
      */
     public function testPropertyDoesNotExist(): void
@@ -112,7 +112,7 @@ class SafeWrapperTest extends TestCase
     }
 
     /**
-     * @expectedException \Error
+     * @expectedException \Exception
      * @expectedExceptionMessage Call to undefined method Linio\SafeEcho\Entity\Customer::getDNExist()
      */
     public function testMethodDoesNotExist(): void
@@ -123,7 +123,7 @@ class SafeWrapperTest extends TestCase
     }
 
     /**
-     * @expectedException \Error
+     * @expectedException \Exception
      * @expectedExceptionMessage Only objects can be wrapped
      */
     public function testDoesNotWrapString(): void
@@ -134,7 +134,7 @@ class SafeWrapperTest extends TestCase
     }
 
     /**
-     * @expectedException \Error
+     * @expectedException \Exception
      * @expectedExceptionMessage Only objects can be wrapped
      */
     public function testDoesNotWrapArray(): void


### PR DESCRIPTION
\Error is reserved for internal PHP errors and should not be used in code. `Error is the base class for all internal PHP errors.` http://php.net/manual/en/class.error.php.

I think we should be throwing more approriate exceptions, but this is a quick fix.

I reverted this change in master as I meant to do this in a branch to make sure there are no other issues with making this change. All the tests pass.

The changes I pushed directly to master were basic cleanup tasks.